### PR TITLE
🐛[fix] fix time to execute

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 on:
   schedule:
-    - cron: 0 7,15,23 * * *
+    - cron: 0 9 * * *
   push:
   workflow_dispatch:
 


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/main.yml` file. The change modifies the cron schedule for the workflow, adjusting the timing to run at 9:00 AM daily instead of the previous schedule of 7:00 AM, 3:00 PM, and 11:00 PM.